### PR TITLE
Test support for S3 presigned urls

### DIFF
--- a/app/geckoModule/services/dataManagerService.js
+++ b/app/geckoModule/services/dataManagerService.js
@@ -22,6 +22,40 @@ class dataManager {
         a.dispatchEvent(e);
     }
 
+    async saveToPresigned(data, { url }) {
+        console.log('presigned', url)
+        try {
+            const resp = await this.$http({
+                method: 'PUT',
+                url,
+                headers: {
+                    'Access-Control-Allow-Origin': true
+                },
+                data
+            })
+
+            if (resp && resp.status === 200) {
+                Swal.fire({
+                    icon: 'success',
+                    title: 'Success',
+                    text: `File successefully uploaded`
+                })
+            } else {
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Upload error',
+                    text: resp.data.error
+                })
+            }
+        } catch (e) {
+            Swal.fire({
+                icon: 'error',
+                title: 'Upload error',
+                text: e.statusText
+            })
+        }
+    }
+
     async saveDataToServer(data, { filename, s3Subfolder }) {
         const spl = filename.split('.')
         const ext = spl.pop()

--- a/tools/presigned.py
+++ b/tools/presigned.py
@@ -1,0 +1,36 @@
+import logging
+import boto3
+from botocore.exceptions import ClientError
+from botocore.client import Config
+
+from argparse import ArgumentParser
+
+
+def create_presigned_put(bucket_name, object_name, expiration=3600):
+    session = boto3.session.Session()
+    s3_client = session.client('s3', config= boto3.session.Config(signature_version='s3v4'))
+    try:
+        response = s3_client.generate_presigned_url('put_object',
+                                                    Params={'Bucket': bucket_name, 'Key': object_name},
+                                                    HttpMethod='PUT',
+                                                    ExpiresIn=expiration)
+    except ClientError as e:
+        logging.error(e)
+        return None
+
+    return response
+
+parser = ArgumentParser()
+
+parser.add_argument("-b", "--bucket", default="gecko-test", help="Bucket name")
+parser.add_argument("-k", "--key", default="test.json", help="Object key")
+parser.add_argument('-e', "--expiration", type=int, default=3600, help="URL expiration")
+
+try:
+    args = parser.parse_args()
+except:
+    parser.error("Invalid arguments.")
+    sys.exit(0)
+
+response = create_presigned_put(args.bucket, args.key, args.expiration)
+print(response)


### PR DESCRIPTION
For generate presigned URL, please use `tools/presigned.py`

`python presigned.py -b bucket_name -k test_folder/test_file.json -e 3600`

That command will print a presigned url for object `test_folder/test_file.json` in bucket `bucket_name` with expiration time 3600 seconds.

After it, you can use that url to directly save to S3 from Gecko:

`https://%GECKO_PATH%/?save_mode=server&audio=%AUDIO_PATH%&json=%TRANSCRIPT_FILE_PATH%&presigned_url=%YOUR_PRESIGNED_URL%` 

For now, pregisned_url agrument should placed last, after test we'll discuss a passing method for presigned urls.