### PR TITLE
Add deprecation notices to project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,16 @@
 ## Contribution
 
-First off, thank you for considering contributing to Gecko. It’s people like you that make open source thrive, and make Gecko a great tool.
+> ## ⚠️ DEPRECATION NOTICE
+> **This project is DEPRECATED and no longer accepting contributions.** The project is archived for historical reference only. We are no longer reviewing pull requests, processing issues, or merging changes. See [README.md](README.md) for full deprecation details.
 
-Gecko is under continuous development. If you have requests for features, please file an issue describing your request. Also, if you want to see work towards a specific feature, feel free to contribute by working towards it. The standard procedure is to fork the repository, add a feature, fix a bug, then file a pull request that your changes are to be merged into the main repository and included in the next release.
+---
+
+### Historical Information (For Reference Only)
+
+First off, thank you for considering contributing to Gecko. It's people like you that make open source thrive, and make Gecko a great tool.
+
+~~Gecko is under continuous development. If you have requests for features, please file an issue describing your request. Also, if you want to see work towards a specific feature, feel free to contribute by working towards it. The standard procedure is to fork the repository, add a feature, fix a bug, then file a pull request that your changes are to be merged into the main repository and included in the next release.~~
+
+**Note:** This information is preserved for historical reference only. The project is no longer accepting contributions.
 
 Here are some tips that might help - [How to contribute to the project](HOW_TO_CONTRIBUTE.md)

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,5 +1,8 @@
 # Installation & Deployment
 
+> ## ⚠️ DEPRECATION NOTICE
+> **This project is DEPRECATED and no longer maintained.** The installation instructions below are preserved for historical reference only. Do NOT use this project for new development. See [README.md](README.md) for full deprecation details.
+
 ## Requirements
 
 * node >= v10

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
+# ⚠️ DEPRECATION NOTICE
+
+## Status: DEPRECATED
+
+This project is **no longer actively maintained** and is considered **obsolete and outdated**.
+
+### Deprecation Details
+
+- **Date Deprecated:** November 2025
+- **Current Status:** Archived for historical reference only
+- **Maintenance:** No active maintenance, no bug fixes, no new features
+- **Support:** No support or assistance will be provided
+
+### Reason for Deprecation
+
+The Gecko project is no longer actively maintained as an open source project and has been superseded by other tools and solutions in the speech annotation ecosystem.
+
+### What This Means
+
+#### ❌ Do NOT:
+- Use this code for new development
+- Expect bug fixes or updates
+- Deploy to any production environment
+- Base new projects on this code
+- Assume dependencies are up to date or secure
+
+#### ✅ You MAY:
+- Reference the code for historical context
+- Study the implementation for learning purposes
+- Extract patterns or ideas (with caution about outdated practices)
+
+### Why Keep It in the Repository?
+
+This project is retained in the repository for:
+- Historical reference
+- Preservation of institutional knowledge
+- Potential future reference in case similar functionality is needed
+
+---
+
 # Gecko - A Tool for Effective Annotation of Human Conversations
 
 ![Comparison](./docs/Comparison.png)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "speech-recognition",
   "version": "1.0.0",
-  "description": "",
+  "deprecated": "This project is no longer maintained and has been archived. See README.md for details.",
+  "description": "DEPRECATED: Gecko - A Tool for Effective Annotation of Human Conversations (No longer maintained as of November 2025)",
   "main": "build/bundle.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Mark the Gecko project as deprecated across all key documentation files:
- README.md: Add prominent deprecation notice at the top
- CONTRIBUTING.md: Note that contributions are no longer accepted
- INSTALLATION.md: Add deprecation warning banner
- package.json: Add deprecated field and update description

The project is archived for historical reference as it is no longer actively maintained as an open source project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)